### PR TITLE
Steps toward making this work.

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 
   <body>
     <div id="elm-area"></div>
-    <script src="elm.js"></script>
     <script src="node_modules/asciidoctor.js/dist/asciidoctor.js"></script>
+    <script src="elm.js"></script>
     <script>
       var app = Elm.Main.fullscreen(
           {

--- a/src/Native/Asciidoc.js
+++ b/src/Native/Asciidoc.js
@@ -1,5 +1,3 @@
-var Asciidoctor = require('asciidoctor.js');
-
 const _user$project$Native_Asciidoc = function() {
 
 


### PR DESCRIPTION
I haven't been able to make this work yet. I'm seeing some problem with the asciidoctor.js NPM package that I can't resolve, and I don't have much time to look into it right now. But I did find a few issues that I've tried to clear up.

First, I removed the `require('asciidoctor.js')` call in `Asciidoc.js`. This call is webpack syntax, and you don't seem to be using webpack. I used that in my implementation, and I find it convenient, so you might look into it. But the short version is that `require()` doesn't work in plain javascript. The asciidoctor.js you'll use is pulled in through the script tag in your HTML (this is the one I was having trouble with).

The second change I made was to reorder your scripts. You'll need asciidoctor.js included before your Elm code tries to use it.

I hope this helps a bit. I can try to answer more questions as you go. Good luck!